### PR TITLE
Improve examples and set module version to v1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Terraform submodules that add functionality to Illumio's CloudSecure Terraform p
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | ~> 1.0.11 |
+| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.0.11 |
 
 ## Providers
 

--- a/examples/aws_account/README.md
+++ b/examples/aws_account/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | ~> 1.0.11 |
+| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.0.11 |
 
 ## Providers
 
@@ -14,7 +14,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | github.com/illumio/terraform-illumio-cloudsecure//modules/aws_account | v1.2.4 |
+| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.3.0 |
 
 ## Resources
 

--- a/examples/aws_account/main.tf
+++ b/examples/aws_account/main.tf
@@ -8,9 +8,10 @@ provider "illumio-cloudsecure" {
 }
 
 module "aws_account_dev" {
-  source = "github.com/illumio/terraform-illumio-cloudsecure//modules/aws_account?ref=v1.3.0"
-  name   = "Test Account"
-  tags   = {
+  source  = "illumio/cloudsecure/illumio//modules/aws_account"
+  version = "1.3.0"
+  name    = "Test Account"
+  tags    = {
     Name  = "CloudSecure Account Policy"
     Owner = "Engineering"
   }

--- a/examples/aws_account/main.tf
+++ b/examples/aws_account/main.tf
@@ -8,7 +8,7 @@ provider "illumio-cloudsecure" {
 }
 
 module "aws_account_dev" {
-  source = "github.com/illumio/terraform-illumio-cloudsecure//modules/aws_account?ref=v1.2.4"
+  source = "github.com/illumio/terraform-illumio-cloudsecure//modules/aws_account?ref=v1.3.0"
   name   = "Test Account"
   tags   = {
     Name  = "CloudSecure Account Policy"

--- a/examples/aws_account/versions.tf
+++ b/examples/aws_account/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.0.11"
+      version = ">= 1.0.11"
     }
     aws = {
       source = "hashicorp/aws"

--- a/examples/aws_flow_logs_s3_buckets/README.md
+++ b/examples/aws_flow_logs_s3_buckets/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | ~> 1.0.11 |
+| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.0.11 |
 
 ## Providers
 
@@ -14,8 +14,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | github.com/illumio/terraform-illumio-cloudsecure//modules/aws_account | v1.2.4 |
-| <a name="module_aws_flow_logs_s3_buckets"></a> [aws\_flow\_logs\_s3\_buckets](#module\_aws\_flow\_logs\_s3\_buckets) | github.com/illumio/terraform-illumio-cloudsecure//modules/aws_flow_logs_s3_buckets | v1.2.4 |
+| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.3.0 |
+| <a name="module_aws_flow_logs_s3_buckets"></a> [aws\_flow\_logs\_s3\_buckets](#module\_aws\_flow\_logs\_s3\_buckets) | illumio/cloudsecure/illumio//modules/aws_flow_logs_s3_buckets | 1.3.0 |
 
 ## Resources
 

--- a/examples/aws_flow_logs_s3_buckets/main.tf
+++ b/examples/aws_flow_logs_s3_buckets/main.tf
@@ -8,16 +8,18 @@ provider "illumio-cloudsecure" {
 }
 
 module "aws_account_dev" {
-  source = "github.com/illumio/terraform-illumio-cloudsecure//modules/aws_account?ref=v1.3.0"
-  name   = "Test Account"
-  tags   = {
+  source  = "illumio/cloudsecure/illumio//modules/aws_account"
+  version = "1.3.0"
+  name    = "Test Account"
+  tags    = {
     Name  = "CloudSecure Account Policy"
     Owner = "Engineering"
   }
 }
 
 module "aws_flow_logs_s3_buckets" {
-  source         = "github.com/illumio/terraform-illumio-cloudsecure//modules/aws_flow_logs_s3_buckets?ref=v1.3.0"
+  source         = "illumio/cloudsecure/illumio//modules/aws_flow_logs_s3_buckets"
+  version        = "1.3.0"
   role_id        = aws_account_dev.role_id
   s3_bucket_arns = [
     "arn:aws:s3:::vpc1",

--- a/examples/aws_flow_logs_s3_buckets/main.tf
+++ b/examples/aws_flow_logs_s3_buckets/main.tf
@@ -8,7 +8,7 @@ provider "illumio-cloudsecure" {
 }
 
 module "aws_account_dev" {
-  source = "github.com/illumio/terraform-illumio-cloudsecure//modules/aws_account?ref=v1.2.4"
+  source = "github.com/illumio/terraform-illumio-cloudsecure//modules/aws_account?ref=v1.3.0"
   name   = "Test Account"
   tags   = {
     Name  = "CloudSecure Account Policy"
@@ -17,7 +17,7 @@ module "aws_account_dev" {
 }
 
 module "aws_flow_logs_s3_buckets" {
-  source         = "github.com/illumio/terraform-illumio-cloudsecure//modules/aws_flow_logs_s3_buckets?ref=v1.2.4"
+  source         = "github.com/illumio/terraform-illumio-cloudsecure//modules/aws_flow_logs_s3_buckets?ref=v1.3.0"
   role_id        = aws_account_dev.role_id
   s3_bucket_arns = [
     "arn:aws:s3:::vpc1",

--- a/examples/aws_flow_logs_s3_buckets/versions.tf
+++ b/examples/aws_flow_logs_s3_buckets/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.0.11"
+      version = ">= 1.0.11"
     }
     aws = {
       source = "hashicorp/aws"

--- a/examples/azure_subscription/README.md
+++ b/examples/azure_subscription/README.md
@@ -16,7 +16,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | github.com/illumio/terraform-illumio-cloudsecure//modules/azure_subscription | v1.3.0 |
+| <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.3.0 |
 
 ## Resources
 

--- a/examples/azure_subscription/main.tf
+++ b/examples/azure_subscription/main.tf
@@ -10,8 +10,9 @@ provider "illumio-cloudsecure" {
 }
 
 module "azure_subscription_dev" {
-  source = "github.com/illumio/terraform-illumio-cloudsecure//modules/azure_subscription?ref=v1.3.0"
-  name   = "Test Azure Subscription"
+  source                 = "illumio/cloudsecure/illumio//modules/azure_subscription"
+  version                = "1.3.0"
+  name                   = "Test Azure Subscription"
   mode                   = "ReadWrite"
   secret_expiration_days = 365
   subscription_id        = "1681e851-ba2d-410b-a66a-9511887e1c1a" # Azure Subscription ID

--- a/examples/k8s_cluster/README.md
+++ b/examples/k8s_cluster/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.15 |
-| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | ~> 1.0.11 |
+| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.0.11 |
 
 ## Providers
 
@@ -14,7 +14,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_k8s_cluster_dev"></a> [k8s\_cluster\_dev](#module\_k8s\_cluster\_dev) | github.com/illumio/terraform-illumio-cloudsecure//modules/k8s_cluster | v1.2.4 |
+| <a name="module_k8s_cluster_dev"></a> [k8s\_cluster\_dev](#module\_k8s\_cluster\_dev) | illumio/cloudsecure/illumio//modules/k8s_cluster | 1.3.0 |
 
 ## Resources
 

--- a/examples/k8s_cluster/main.tf
+++ b/examples/k8s_cluster/main.tf
@@ -10,7 +10,7 @@ provider "illumio-cloudsecure" {
 }
 
 module "k8s_cluster_dev" {
-  source         = "github.com/illumio/terraform-illumio-cloudsecure//modules/k8s_cluster?ref=v1.2.4"
+  source         = "github.com/illumio/terraform-illumio-cloudsecure//modules/k8s_cluster?ref=v1.3.0"
   illumio_region = "aws-us-west-2"
   name           = "example-release"
   description    = "Dev cluster in aws-us-west-2"

--- a/examples/k8s_cluster/main.tf
+++ b/examples/k8s_cluster/main.tf
@@ -10,7 +10,8 @@ provider "illumio-cloudsecure" {
 }
 
 module "k8s_cluster_dev" {
-  source         = "github.com/illumio/terraform-illumio-cloudsecure//modules/k8s_cluster?ref=v1.3.0"
+  source         = "illumio/cloudsecure/illumio//modules/k8s_cluster"
+  version        = "1.3.0"
   illumio_region = "aws-us-west-2"
   name           = "example-release"
   description    = "Dev cluster in aws-us-west-2"

--- a/examples/k8s_cluster/versions.tf
+++ b/examples/k8s_cluster/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.0.11"
+      version = ">= 1.0.11"
     }
     helm = {
       source = "hashicorp/helm"

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.0.11"
+      version = ">= 1.0.11"
     }
   }
 }

--- a/modules/aws_account/README.md
+++ b/modules/aws_account/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | ~> 1.0.11 |
+| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.0.11 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
@@ -12,7 +12,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_illumio-cloudsecure"></a> [illumio-cloudsecure](#provider\_illumio-cloudsecure) | ~> 1.0.11 |
+| <a name="provider_illumio-cloudsecure"></a> [illumio-cloudsecure](#provider\_illumio-cloudsecure) | >= 1.0.11 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/modules/aws_account/versions.tf
+++ b/modules/aws_account/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.0.11"
+      version = ">= 1.0.11"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/modules/aws_flow_logs_s3_buckets/README.md
+++ b/modules/aws_flow_logs_s3_buckets/README.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
-| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | ~> 1.0.11 |
+| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.0.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.0 |
-| <a name="provider_illumio-cloudsecure"></a> [illumio-cloudsecure](#provider\_illumio-cloudsecure) | ~> 1.0.11 |
+| <a name="provider_illumio-cloudsecure"></a> [illumio-cloudsecure](#provider\_illumio-cloudsecure) | >= 1.0.11 |
 
 ## Modules
 

--- a/modules/aws_flow_logs_s3_buckets/versions.tf
+++ b/modules/aws_flow_logs_s3_buckets/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.0.11"
+      version = ">= 1.0.11"
     }
     aws = {
       source  = "hashicorp/aws"

--- a/modules/k8s_cluster/README.md
+++ b/modules/k8s_cluster/README.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.15 |
-| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | ~> 1.0.11 |
+| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.0.11 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.15 |
-| <a name="provider_illumio-cloudsecure"></a> [illumio-cloudsecure](#provider\_illumio-cloudsecure) | ~> 1.0.11 |
+| <a name="provider_illumio-cloudsecure"></a> [illumio-cloudsecure](#provider\_illumio-cloudsecure) | >= 1.0.11 |
 
 ## Modules
 

--- a/modules/k8s_cluster/versions.tf
+++ b/modules/k8s_cluster/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = "~> 1.0.11"
+      version = ">= 1.0.11"
     }
     helm = {
       source = "hashicorp/helm"


### PR DESCRIPTION
Set module version to 1.3.0.

Update the versions constraints on provider illumio-cloudsecure in all modules and examples to use `>=` instead of `~>`.

Update the format of module source/version in all examples.