### PR TITLE
aws_flow_logs: Fix path prefixes in configured permissions

### DIFF
--- a/modules/aws_flow_logs_s3_buckets/main.tf
+++ b/modules/aws_flow_logs_s3_buckets/main.tf
@@ -40,7 +40,7 @@ resource "aws_iam_role_policy" "s3_bucket_list" {
           Condition = {
             StringLike = {
               "s3:prefix" = [
-                replace("${regex("/.*/.*", arn)}/*", "//*", "/*")
+                trimprefix(replace("${regex("/.*/.*", arn)}/*", "//*", "/*"), "/")
               ]
             }
           }


### PR DESCRIPTION
The path prefix shouldn't include prefix `/` as the `s3_prefix` condition requires each path to not start with `/`.