### PR TITLE
k8s_cluster: Replace the k8s_cluster_onboarding_credential resource with a k8s_cluster

### DIFF
--- a/modules/k8s_cluster/README.md
+++ b/modules/k8s_cluster/README.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.15 |
-| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.0.11 |
+| <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.15 |
-| <a name="provider_illumio-cloudsecure"></a> [illumio-cloudsecure](#provider\_illumio-cloudsecure) | >= 1.0.11 |
+| <a name="provider_illumio-cloudsecure"></a> [illumio-cloudsecure](#provider\_illumio-cloudsecure) | >= 1.4.0 |
 
 ## Modules
 
@@ -22,16 +22,15 @@ No modules.
 | Name | Type |
 |------|------|
 | [helm_release.helm_cloud_operator](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [illumio-cloudsecure_k8s_cluster_onboarding_credential.this](https://registry.terraform.io/providers/illumio/illumio-cloudsecure/latest/docs/resources/k8s_cluster_onboarding_credential) | resource |
+| [illumio-cloudsecure_k8s_cluster.this](https://registry.terraform.io/providers/illumio/illumio-cloudsecure/latest/docs/resources/k8s_cluster) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_create_operator_namespace"></a> [create\_operator\_namespace](#input\_create\_operator\_namespace) | If true, creates the k8s namespace where cloud-operator is to be deployed if it does not exist. | `bool` | `true` | no |
-| <a name="input_description"></a> [description](#input\_description) | The description of the CloudSecure onboarding credential used to onboard the k8s cluster. | `string` | `""` | no |
 | <a name="input_illumio_region"></a> [illumio\_region](#input\_illumio\_region) | Illumio Region where the k8s cluster can be onboarded using this credential. An Illumio Region is a designated cloud region where the CloudSecure k8s operators in onboarded k8s clusters connect after onboarding. Choose the Illumio Region nearest to each cluster to maximize performance and security. Must be one of: `aws-ap-southeast-2`, `aws-eu-west-2`, `aws-us-west-2`, `aws-us-west-1`, `aws-eu-west-2`, `azure-us-east-2`, `azure-germany-west-central`, `azure-us-west-2`. | `string` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | The name of the cloud-secure deployment in the k8s cluster and of the CloudSecure onboarding credential used to onboard the k8s cluster. | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | The name of the cloud-secure deployment in the k8s cluster. | `string` | n/a | yes |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | The k8s namespace where cloud-operator is to be deployed into. | `string` | `"illumio-cloud"` | no |
 | <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | The version of cloud-operator to be deployed into the k8s cluster. | `string` | `"v1.1.1"` | no |
 

--- a/modules/k8s_cluster/main.tf
+++ b/modules/k8s_cluster/main.tf
@@ -1,7 +1,5 @@
-resource "illumio-cloudsecure_k8s_cluster_onboarding_credential" "this" {
+resource "illumio-cloudsecure_k8s_cluster" "this" {
   illumio_region = var.illumio_region
-  name           = var.name
-  description    = var.description
 }
 
 resource "helm_release" "helm_cloud_operator" {
@@ -12,12 +10,12 @@ resource "helm_release" "helm_cloud_operator" {
   create_namespace = var.create_operator_namespace
 
   set {
-    name  = "onboardingSecret.clientId"
-    value = illumio-cloudsecure_k8s_cluster_onboarding_credential.this.client_id
+    name  = "clusterCredsSecret.clientId"
+    value = illumio-cloudsecure_k8s_cluster.this.client_id
   }
 
   set {
-    name  = "onboardingSecret.clientSecret"
-    value = illumio-cloudsecure_k8s_cluster_onboarding_credential.this.client_secret
+    name  = "clusterCredsSecret.clientSecret"
+    value = illumio-cloudsecure_k8s_cluster.this.client_secret
   }
 }

--- a/modules/k8s_cluster/variables.tf
+++ b/modules/k8s_cluster/variables.tf
@@ -4,14 +4,8 @@ variable "illumio_region" {
 }
 
 variable "name" {
-  description = "The name of the cloud-secure deployment in the k8s cluster and of the CloudSecure onboarding credential used to onboard the k8s cluster."
+  description = "The name of the cloud-secure deployment in the k8s cluster."
   type        = string
-}
-
-variable "description" {
-  description = "The description of the CloudSecure onboarding credential used to onboard the k8s cluster."
-  type        = string
-  default     = ""
 }
 
 variable "operator_namespace" {

--- a/modules/k8s_cluster/versions.tf
+++ b/modules/k8s_cluster/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"
-      version = ">= 1.0.11"
+      version = ">= 1.4.0"
     }
     helm = {
       source = "hashicorp/helm"


### PR DESCRIPTION
Replace the k8s cluster onboarding flow using an onboarding credential with a direct onboarding using the service account configured for the Terraform provider.