### PR TITLE
Bump default version of cloud-operator to v1.3.1

### DIFF
--- a/examples/aws_account/README.md
+++ b/examples/aws_account/README.md
@@ -14,7 +14,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.5.2 |
+| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.5.3 |
 
 ## Resources
 

--- a/examples/aws_account/main.tf
+++ b/examples/aws_account/main.tf
@@ -9,7 +9,7 @@ provider "illumio-cloudsecure" {
 
 module "aws_account_dev" {
   source  = "illumio/cloudsecure/illumio//modules/aws_account"
-  version = "1.5.2"
+  version = "1.5.3"
   name    = "Test Account"
   tags    = {
     Name  = "CloudSecure Account Policy"

--- a/examples/aws_flow_logs_s3_buckets/README.md
+++ b/examples/aws_flow_logs_s3_buckets/README.md
@@ -14,8 +14,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.5.2 |
-| <a name="module_aws_flow_logs_s3_buckets"></a> [aws\_flow\_logs\_s3\_buckets](#module\_aws\_flow\_logs\_s3\_buckets) | illumio/cloudsecure/illumio//modules/aws_flow_logs_s3_buckets | 1.5.2 |
+| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.5.3 |
+| <a name="module_aws_flow_logs_s3_buckets"></a> [aws\_flow\_logs\_s3\_buckets](#module\_aws\_flow\_logs\_s3\_buckets) | illumio/cloudsecure/illumio//modules/aws_flow_logs_s3_buckets | 1.5.3 |
 
 ## Resources
 

--- a/examples/aws_flow_logs_s3_buckets/main.tf
+++ b/examples/aws_flow_logs_s3_buckets/main.tf
@@ -9,7 +9,7 @@ provider "illumio-cloudsecure" {
 
 module "aws_account_dev" {
   source  = "illumio/cloudsecure/illumio//modules/aws_account"
-  version = "1.5.2"
+  version = "1.5.3"
   name    = "Test Account"
   tags    = {
     Name  = "CloudSecure Account Policy"
@@ -19,7 +19,7 @@ module "aws_account_dev" {
 
 module "aws_flow_logs_s3_buckets" {
   source         = "illumio/cloudsecure/illumio//modules/aws_flow_logs_s3_buckets"
-  version        = "1.5.2"
+  version        = "1.5.3"
   role_id        = aws_account_dev.role_id
   s3_bucket_arns = [
     "arn:aws:s3:::flows-bucket-1",

--- a/examples/azure_flow_logs_storage_accounts/README.md
+++ b/examples/azure_flow_logs_storage_accounts/README.md
@@ -14,8 +14,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_flow_logs_storage_accounts"></a> [azure\_flow\_logs\_storage\_accounts](#module\_azure\_flow\_logs\_storage\_accounts) | illumio/cloudsecure/illumio//modules/azure_flow_logs_storage_accounts | 1.5.2 |
-| <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.5.2 |
+| <a name="module_azure_flow_logs_storage_accounts"></a> [azure\_flow\_logs\_storage\_accounts](#module\_azure\_flow\_logs\_storage\_accounts) | illumio/cloudsecure/illumio//modules/azure_flow_logs_storage_accounts | 1.5.3 |
+| <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.5.3 |
 
 ## Resources
 

--- a/examples/azure_flow_logs_storage_accounts/main.tf
+++ b/examples/azure_flow_logs_storage_accounts/main.tf
@@ -19,7 +19,7 @@ provider "illumio-cloudsecure" {
 
 module "azure_subscription_dev" {
   source                 = "illumio/cloudsecure/illumio//modules/azure_subscription"
-  version                = "1.5.2"
+  version                = "1.5.3"
   name                   = "Test Azure Subscription"
   mode                   = "ReadWrite"
   secret_expiration_days = 365
@@ -34,7 +34,7 @@ module "azure_subscription_dev" {
 
 module "azure_flow_logs_storage_accounts" {
   source                      = "illumio/cloudsecure/illumio//modules/azure_flow_logs_storage_accounts"
-  version                     = "1.5.2"
+  version                     = "1.5.3"
   service_principal_client_id = module.azure_subscription_dev.service_principal_client_id
 
   storage_accounts = [

--- a/examples/azure_subscription/README.md
+++ b/examples/azure_subscription/README.md
@@ -16,7 +16,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.5.2 |
+| <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.5.3 |
 
 ## Resources
 

--- a/examples/azure_subscription/main.tf
+++ b/examples/azure_subscription/main.tf
@@ -19,7 +19,7 @@ provider "illumio-cloudsecure" {
 
 module "azure_subscription_dev" {
   source                 = "illumio/cloudsecure/illumio//modules/azure_subscription"
-  version                = "1.5.2"
+  version                = "1.5.3"
   name                   = "Test Azure Subscription"
   mode                   = "ReadWrite"
   secret_expiration_days = 365

--- a/examples/k8s_cluster/README.md
+++ b/examples/k8s_cluster/README.md
@@ -14,7 +14,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_k8s_cluster_dev"></a> [k8s\_cluster\_dev](#module\_k8s\_cluster\_dev) | illumio/cloudsecure/illumio//modules/k8s_cluster | 1.5.2 |
+| <a name="module_k8s_cluster_dev"></a> [k8s\_cluster\_dev](#module\_k8s\_cluster\_dev) | illumio/cloudsecure/illumio//modules/k8s_cluster | 1.5.3 |
 
 ## Resources
 

--- a/examples/k8s_cluster/main.tf
+++ b/examples/k8s_cluster/main.tf
@@ -11,7 +11,7 @@ provider "illumio-cloudsecure" {
 
 module "k8s_cluster_dev" {
   source           = "illumio/cloudsecure/illumio//modules/k8s_cluster"
-  version          = "1.5.2"
+  version          = "1.5.3"
   illumio_region   = "aws-us-west-2"
   name             = "example-release"
 

--- a/examples/k8s_cluster/main.tf
+++ b/examples/k8s_cluster/main.tf
@@ -20,5 +20,5 @@ module "k8s_cluster_dev" {
   enable_falco              = false
   https_proxy               = "http://proxy.example.com:8080"
   operator_namespace        = "illumio-cloud"
-  operator_version          = "v1.1.3"
+  operator_version          = "v1.3.1"
 }

--- a/modules/k8s_cluster/README.md
+++ b/modules/k8s_cluster/README.md
@@ -34,7 +34,7 @@ No modules.
 | <a name="input_illumio_region"></a> [illumio\_region](#input\_illumio\_region) | Illumio Region where the k8s cluster will be onboarded. An Illumio Region is a designated cloud region where the CloudSecure cloud-operator deployed in the k8s cluster connects after onboarding. Choose the Illumio Region nearest to the k8s cluster to maximize performance and security. Must be one of: `aws-ap-southeast-2`, `aws-eu-west-2`, `aws-us-west-2`, `aws-us-west-1`, `aws-eu-west-2`, `azure-us-east-2`, `azure-germany-west-central`, `azure-us-west-2`. | `string` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | The name of the cloud-secure deployment in the k8s cluster. | `string` | n/a | yes |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | The k8s namespace where cloud-operator is to be deployed into. | `string` | `"illumio-cloud"` | no |
-| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | The version of cloud-operator to be deployed into the k8s cluster. | `string` | `"v1.3.0"` | no |
+| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | The version of cloud-operator to be deployed into the k8s cluster. | `string` | `"v1.3.1"` | no |
 
 ## Outputs
 

--- a/modules/k8s_cluster/variables.tf
+++ b/modules/k8s_cluster/variables.tf
@@ -36,5 +36,5 @@ variable "operator_namespace" {
 variable "operator_version" {
   description = "The version of cloud-operator to be deployed into the k8s cluster."
   type        = string
-  default     = "v1.3.0"
+  default     = "v1.3.1"
 }


### PR DESCRIPTION
Bump default version of cloud-operator to [v1.3.1](https://github.com/illumio/cloud-operator/releases/tag/v1.3.1).
Set module version to 1.5.3 in examples.