### PR TITLE
k8s_cluster: Add cluster_name variable to override k8s cluster display name

### DIFF
--- a/examples/aws_account/README.md
+++ b/examples/aws_account/README.md
@@ -14,7 +14,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.6.6 |
+| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.6.7 |
 
 ## Resources
 

--- a/examples/aws_account/main.tf
+++ b/examples/aws_account/main.tf
@@ -9,7 +9,7 @@ provider "illumio-cloudsecure" {
 
 module "aws_account_dev" {
   source  = "illumio/cloudsecure/illumio//modules/aws_account"
-  version = "1.6.6"
+  version = "1.6.7"
   name    = "Test Account"
   tags    = {
     Name  = "CloudSecure Account Policy"

--- a/examples/aws_flow_logs_s3_buckets/README.md
+++ b/examples/aws_flow_logs_s3_buckets/README.md
@@ -14,8 +14,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.6.6 |
-| <a name="module_aws_flow_logs_s3_buckets"></a> [aws\_flow\_logs\_s3\_buckets](#module\_aws\_flow\_logs\_s3\_buckets) | illumio/cloudsecure/illumio//modules/aws_flow_logs_s3_buckets | 1.6.6 |
+| <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.6.7 |
+| <a name="module_aws_flow_logs_s3_buckets"></a> [aws\_flow\_logs\_s3\_buckets](#module\_aws\_flow\_logs\_s3\_buckets) | illumio/cloudsecure/illumio//modules/aws_flow_logs_s3_buckets | 1.6.7 |
 
 ## Resources
 

--- a/examples/aws_flow_logs_s3_buckets/main.tf
+++ b/examples/aws_flow_logs_s3_buckets/main.tf
@@ -9,7 +9,7 @@ provider "illumio-cloudsecure" {
 
 module "aws_account_dev" {
   source  = "illumio/cloudsecure/illumio//modules/aws_account"
-  version = "1.6.6"
+  version = "1.6.7"
   name    = "Test Account"
   tags    = {
     Name  = "CloudSecure Account Policy"
@@ -19,7 +19,7 @@ module "aws_account_dev" {
 
 module "aws_flow_logs_s3_buckets" {
   source         = "illumio/cloudsecure/illumio//modules/aws_flow_logs_s3_buckets"
-  version        = "1.6.6"
+  version        = "1.6.7"
   role_id        = aws_account_dev.role_id
   s3_bucket_arns = [
     "arn:aws:s3:::flows-bucket-1",

--- a/examples/azure_flow_logs_storage_accounts/README.md
+++ b/examples/azure_flow_logs_storage_accounts/README.md
@@ -14,7 +14,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_flow_logs_storage_accounts"></a> [azure\_flow\_logs\_storage\_accounts](#module\_azure\_flow\_logs\_storage\_accounts) | illumio/cloudsecure/illumio//modules/azure_flow_logs_storage_accounts | 1.6.6 |
+| <a name="module_azure_flow_logs_storage_accounts"></a> [azure\_flow\_logs\_storage\_accounts](#module\_azure\_flow\_logs\_storage\_accounts) | illumio/cloudsecure/illumio//modules/azure_flow_logs_storage_accounts | 1.6.7 |
 | <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.3 |
 
 ## Resources

--- a/examples/azure_flow_logs_storage_accounts/main.tf
+++ b/examples/azure_flow_logs_storage_accounts/main.tf
@@ -34,7 +34,7 @@ module "azure_subscription_dev" {
 
 module "azure_flow_logs_storage_accounts" {
   source                      = "illumio/cloudsecure/illumio//modules/azure_flow_logs_storage_accounts"
-  version                     = "1.6.6"
+  version                     = "1.6.7"
   service_principal_client_id = module.azure_subscription_dev.service_principal_client_id
 
   storage_accounts = [

--- a/examples/azure_subscription/README.md
+++ b/examples/azure_subscription/README.md
@@ -16,7 +16,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.6.6 |
+| <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.6.7 |
 
 ## Resources
 

--- a/examples/azure_subscription/main.tf
+++ b/examples/azure_subscription/main.tf
@@ -19,7 +19,7 @@ provider "illumio-cloudsecure" {
 
 module "azure_subscription_dev" {
   source                 = "illumio/cloudsecure/illumio//modules/azure_subscription"
-  version                = "1.6.6"
+  version                = "1.6.7"
   name                   = "Test Azure Subscription"
   mode                   = "ReadWrite"
   secret_expiration_days = 365

--- a/examples/gcp_flow_logs_pubsub_topic/README.md
+++ b/examples/gcp_flow_logs_pubsub_topic/README.md
@@ -14,8 +14,8 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_gcp_flow_logs_pubsub_topic_dev"></a> [gcp\_flow\_logs\_pubsub\_topic\_dev](#module\_gcp\_flow\_logs\_pubsub\_topic\_dev) | illumio/cloudsecure/illumio//modules/gcp_flow_logs_pubsub_topic | 1.6.6 |
-| <a name="module_gcp_project_dev"></a> [gcp\_project\_dev](#module\_gcp\_project\_dev) | illumio/cloudsecure/illumio//modules/gcp_project | 1.6.6 |
+| <a name="module_gcp_flow_logs_pubsub_topic_dev"></a> [gcp\_flow\_logs\_pubsub\_topic\_dev](#module\_gcp\_flow\_logs\_pubsub\_topic\_dev) | illumio/cloudsecure/illumio//modules/gcp_flow_logs_pubsub_topic | 1.6.7 |
+| <a name="module_gcp_project_dev"></a> [gcp\_project\_dev](#module\_gcp\_project\_dev) | illumio/cloudsecure/illumio//modules/gcp_project | 1.6.7 |
 
 ## Resources
 

--- a/examples/gcp_flow_logs_pubsub_topic/main.tf
+++ b/examples/gcp_flow_logs_pubsub_topic/main.tf
@@ -9,7 +9,7 @@ provider "illumio-cloudsecure" {
 
 module "gcp_project_dev" {
   source  = "illumio/cloudsecure/illumio//modules/gcp_project"
-  version = "1.6.6"
+  version = "1.6.7"
 
   project_id      = "my-project-id"
   organization_id = "123456789012"
@@ -19,7 +19,7 @@ module "gcp_project_dev" {
 
 module "gcp_flow_logs_pubsub_topic_dev" {
   source  = "illumio/cloudsecure/illumio//modules/gcp_flow_logs_pubsub_topic"
-  version = "1.6.6"
+  version = "1.6.7"
 
   project_id            = "my-project-id"
   service_account_email = module.gcp_project_dev.service_account_email

--- a/examples/gcp_project/README.md
+++ b/examples/gcp_project/README.md
@@ -14,7 +14,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_gcp_project_dev"></a> [gcp\_project\_dev](#module\_gcp\_project\_dev) | illumio/cloudsecure/illumio//modules/gcp_project | 1.6.6 |
+| <a name="module_gcp_project_dev"></a> [gcp\_project\_dev](#module\_gcp\_project\_dev) | illumio/cloudsecure/illumio//modules/gcp_project | 1.6.7 |
 
 ## Resources
 

--- a/examples/gcp_project/main.tf
+++ b/examples/gcp_project/main.tf
@@ -9,7 +9,7 @@ provider "illumio-cloudsecure" {
 
 module "gcp_project_dev" {
   source  = "illumio/cloudsecure/illumio//modules/gcp_project"
-  version = "1.6.6"
+  version = "1.6.7"
 
   project_id      = "my-project-id"
   organization_id = "123456789012"

--- a/examples/k8s_cluster/README.md
+++ b/examples/k8s_cluster/README.md
@@ -14,7 +14,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_k8s_cluster_dev"></a> [k8s\_cluster\_dev](#module\_k8s\_cluster\_dev) | illumio/cloudsecure/illumio//modules/k8s_cluster | 1.6.6 |
+| <a name="module_k8s_cluster_dev"></a> [k8s\_cluster\_dev](#module\_k8s\_cluster\_dev) | illumio/cloudsecure/illumio//modules/k8s_cluster | 1.6.7 |
 
 ## Resources
 

--- a/examples/k8s_cluster/main.tf
+++ b/examples/k8s_cluster/main.tf
@@ -11,12 +11,13 @@ provider "illumio-cloudsecure" {
 
 module "k8s_cluster_dev" {
   source           = "illumio/cloudsecure/illumio//modules/k8s_cluster"
-  version          = "1.6.6"
+  version          = "1.6.7"
   illumio_region   = "aws-us-west-2"
   name             = "example-release"
 
   # Optional attributes
   cilium_namespaces           = ["kube-system", "gke-managed-dpv2-observability"]
+  cluster_name                = "test-cluster-12"
   create_operator_namespace   = true
   enable_falco                = false
   https_proxy                 = "http://proxy.example.com:8080"

--- a/modules/k8s_cluster/README.md
+++ b/modules/k8s_cluster/README.md
@@ -29,6 +29,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_cilium_namespaces"></a> [cilium\_namespaces](#input\_cilium\_namespaces) | The namespaces in which Cilium may be deployed. | `list(string)` | <pre>[<br/>  "kube-system",<br/>  "gke-managed-dpv2-observability"<br/>]</pre> | no |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the k8s cluster to be displayed in Illumio CloudSecure. If empty, defaults to the name of the cluster returned by the cloud provider's API, if configured. | `string` | `null` | no |
 | <a name="input_create_operator_namespace"></a> [create\_operator\_namespace](#input\_create\_operator\_namespace) | If true, creates the k8s namespace where cloud-operator is to be deployed if it does not exist. | `bool` | `true` | no |
 | <a name="input_enable_falco"></a> [enable\_falco](#input\_enable\_falco) | If true, deploys the Falco agent along with cloud-operator to collect network flows. | `bool` | `false` | no |
 | <a name="input_https_proxy"></a> [https\_proxy](#input\_https\_proxy) | The URL of the HTTPS proxy to be used by cloud-operator to connect to Illumio CloudSecure. If not set, no proxy will be used. | `string` | `null` | no |
@@ -38,7 +39,7 @@ No modules.
 | <a name="input_openshift_ovnk_namespace"></a> [openshift\_ovnk\_namespace](#input\_openshift\_ovnk\_namespace) | The namespace in which OpenShift OVN-k is deployed. | `string` | `"openshift-ovn-kubernetes"` | no |
 | <a name="input_openshift_worker_node_cidrs"></a> [openshift\_worker\_node\_cidrs](#input\_openshift\_worker\_node\_cidrs) | The list of IP address CIDRs of the OpenShift cluster's worker nodes. Used to restrict access from only those nodes to the IPFIX collector on UDP port 4739 in the NetworkPolicy. If empty, defaults to allowing ingress traffic to UDP port 4739 from any address. This is a safe default only on clusters that are not running OpenShift with OVN-k, because port 4739 is not open in that case. | `list(string)` | `[]` | no |
 | <a name="input_operator_namespace"></a> [operator\_namespace](#input\_operator\_namespace) | The k8s namespace where cloud-operator is to be deployed into. | `string` | `"illumio-cloud"` | no |
-| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | The version of cloud-operator to be deployed into the k8s cluster. | `string` | `"v1.3.12"` | no |
+| <a name="input_operator_version"></a> [operator\_version](#input\_operator\_version) | The version of cloud-operator to be deployed into the k8s cluster. | `string` | `"v1.3.13"` | no |
 | <a name="input_stats_log_period"></a> [stats\_log\_period](#input\_stats\_log\_period) | The interval between log entries with statistics about the network flows and resource mutations that were sent to the server. | `string` | `"30m"` | no |
 
 ## Outputs

--- a/modules/k8s_cluster/main.tf
+++ b/modules/k8s_cluster/main.tf
@@ -12,6 +12,10 @@ resource "helm_release" "helm_cloud_operator" {
 
   set = [
     {
+      name = "cluster.name"
+      value = var.cluster_name
+    },
+    {
       name  = "clusterCredsSecret.clientId"
       value = illumio-cloudsecure_k8s_cluster.this.client_id
     },

--- a/modules/k8s_cluster/variables.tf
+++ b/modules/k8s_cluster/variables.tf
@@ -11,6 +11,13 @@ variable "cilium_namespaces" {
   }
 }
 
+variable "cluster_name" {
+  description = "The name of the k8s cluster to be displayed in Illumio CloudSecure. If empty, defaults to the name of the cluster returned by the cloud provider's API, if configured."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
 variable "create_operator_namespace" {
   description = "If true, creates the k8s namespace where cloud-operator is to be deployed if it does not exist."
   type        = bool
@@ -87,7 +94,7 @@ variable "operator_namespace" {
 variable "operator_version" {
   description = "The version of cloud-operator to be deployed into the k8s cluster."
   type        = string
-  default     = "v1.3.12"
+  default     = "v1.3.13"
   validation {
     condition     = length(var.operator_version) > 0
     error_message = "The operator_version value must not be empty."


### PR DESCRIPTION
Update default `operator_version` to latest version 1.3.13, which adds the `cluster.name` Helm variable.
Set version to v1.6.7.