### PR TITLE
azure_subscription: Support using an existing app registration and client secret

### DIFF
--- a/examples/azure_subscription/README.md
+++ b/examples/azure_subscription/README.md
@@ -3,6 +3,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.0 |
 | <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.2.0 |
@@ -17,6 +18,7 @@ No providers.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.6.7 |
+| <a name="module_azure_subscription_existing_sp"></a> [azure\_subscription\_existing\_sp](#module\_azure\_subscription\_existing\_sp) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.6.7 |
 
 ## Resources
 
@@ -32,6 +34,8 @@ No resources.
 | <a name="input_azure_tenant_id"></a> [azure\_tenant\_id](#input\_azure\_tenant\_id) | The Azure Tenant ID. | `string` | n/a | yes |
 | <a name="input_illumio_cloudsecure_client_id"></a> [illumio\_cloudsecure\_client\_id](#input\_illumio\_cloudsecure\_client\_id) | The OAuth 2 client identifier used to authenticate against the CloudSecure Config API. | `string` | n/a | yes |
 | <a name="input_illumio_cloudsecure_client_secret"></a> [illumio\_cloudsecure\_client\_secret](#input\_illumio\_cloudsecure\_client\_secret) | The OAuth 2 client secret used to authenticate against the CloudSecure Config API. | `string` | n/a | yes |
+| <a name="input_illumio_service_principal_client_id"></a> [illumio\_service\_principal\_client\_id](#input\_illumio\_service\_principal\_client\_id) | The client ID (application ID) of a pre-existing Azure AD application/service principal to wire into the second example module instance. | `string` | n/a | yes |
+| <a name="input_illumio_service_principal_client_secret"></a> [illumio\_service\_principal\_client\_secret](#input\_illumio\_service\_principal\_client\_secret) | The client secret for the pre-existing Azure AD application referenced by illumio\_service\_principal\_client\_id. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/azure_subscription/main.tf
+++ b/examples/azure_subscription/main.tf
@@ -31,3 +31,20 @@ module "azure_subscription_dev" {
     "Owner=John Doe"
   ]
 }
+
+# Reuse a pre-existing Azure AD application/service principal instead of
+# letting the module create one. service_principal_client_id and
+# service_principal_client_secret must both be set (or both null).
+module "azure_subscription_existing_sp" {
+  source                          = "illumio/cloudsecure/illumio//modules/azure_subscription"
+  version                         = "1.6.7"
+  name                            = "Test Azure Subscription (existing service principal)"
+  mode                            = "ReadWrite"
+  service_principal_client_id     = var.illumio_service_principal_client_id
+  service_principal_client_secret = var.illumio_service_principal_client_secret
+
+  tags = [
+    "Environment=Dev",
+    "Owner=John Doe"
+  ]
+}

--- a/examples/azure_subscription/variables.tf
+++ b/examples/azure_subscription/variables.tf
@@ -53,3 +53,22 @@ variable "azure_tenant_id" {
     error_message = "The azure_tenant_id value must not be empty."
   }
 }
+
+variable "illumio_service_principal_client_id" {
+  type        = string
+  description = "The client ID (application ID) of a pre-existing Azure AD application/service principal to wire into the second example module instance."
+  validation {
+    condition     = length(var.illumio_service_principal_client_id) > 0
+    error_message = "The illumio_service_principal_client_id value must not be empty."
+  }
+}
+
+variable "illumio_service_principal_client_secret" {
+  type        = string
+  sensitive   = true
+  description = "The client secret for the pre-existing Azure AD application referenced by illumio_service_principal_client_id."
+  validation {
+    condition     = length(var.illumio_service_principal_client_secret) > 0
+    error_message = "The illumio_service_principal_client_secret value must not be empty."
+  }
+}

--- a/examples/azure_subscription/versions.tf
+++ b/examples/azure_subscription/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.9"
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"

--- a/modules/azure_subscription/README.md
+++ b/modules/azure_subscription/README.md
@@ -34,7 +34,6 @@ No modules.
 | [azurerm_role_definition.illumio_fw_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.illumio_nsg_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [illumio-cloudsecure_azure_subscription.subscription](https://registry.terraform.io/providers/illumio/illumio-cloudsecure/latest/docs/resources/azure_subscription) | resource |
-| [terraform_data.validate_existing_credentials](https://developer.hashicorp.com/terraform/language/resources/terraform-data) | resource |
 | [time_rotating.secret_rotation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 | [azuread_service_principal.existing](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
@@ -45,11 +44,11 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azure_secret_expiration_days"></a> [azure\_secret\_expiration\_days](#input\_azure\_secret\_expiration\_days) | The number of days the Azure service principal secret remains valid before requiring renewal. | `number` | `365` | no |
-| <a name="input_existing_client_id"></a> [existing\_client\_id](#input\_existing\_client\_id) | Optional. The client ID (application ID) of a pre-existing Azure AD application to use instead of creating a new one. When set, the module skips creating the azuread\_application, azuread\_service\_principal, and azuread\_application\_password resources and looks up the existing service principal by client\_id (which requires the executing identity to have directory read access). existing\_client\_secret must also be set. | `string` | `null` | no |
-| <a name="input_existing_client_secret"></a> [existing\_client\_secret](#input\_existing\_client\_secret) | Optional. The client secret for the pre-existing Azure AD application referenced by existing\_client\_id. Required when existing\_client\_id is set. Rotation of this secret is the caller's responsibility; azure\_secret\_expiration\_days is ignored in this mode. | `string` | `null` | no |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | The prefix given to all Azure resource names. | `string` | `"IllumioCloudIntegration"` | no |
 | <a name="input_mode"></a> [mode](#input\_mode) | The account's access mode, must be "ReadWrite" (default) or "Read". | `string` | `"ReadWrite"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of this subscription in CloudSecure. | `string` | n/a | yes |
+| <a name="input_service_principal_client_id"></a> [service\_principal\_client\_id](#input\_service\_principal\_client\_id) | Optional. The client ID (application ID) of a pre-existing Azure AD application to use instead of creating a new one. When set, the module skips creating the azuread\_application, azuread\_service\_principal, and azuread\_application\_password resources and looks up the existing service principal by client\_id (which requires the executing identity to have directory read access). service\_principal\_client\_secret must also be set. | `string` | `null` | no |
+| <a name="input_service_principal_client_secret"></a> [service\_principal\_client\_secret](#input\_service\_principal\_client\_secret) | Optional. The client secret for the pre-existing Azure AD application identified by service\_principal\_client\_id. Required when service\_principal\_client\_id is set. Rotation of this secret is the caller's responsibility; azure\_secret\_expiration\_days is ignored in this mode. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The optional tags added to every configured Azure resource. | `set(string)` | `[]` | no |
 
 ## Outputs
@@ -59,5 +58,5 @@ No modules.
 | <a name="output_azure_secret_expiration_days"></a> [azure\_secret\_expiration\_days](#output\_azure\_secret\_expiration\_days) | The number of days the Azure service principal secret remains valid before requiring renewal. |
 | <a name="output_iam_name_prefix"></a> [iam\_name\_prefix](#output\_iam\_name\_prefix) | The prefix given to all Azure resource names. |
 | <a name="output_mode"></a> [mode](#output\_mode) | The account's access mode, must be "ReadWrite" (default) or "Read". |
-| <a name="output_service_principal_client_id"></a> [service\_principal\_client\_id](#output\_service\_principal\_client\_id) | The object ID of the service principal used for Illumio CloudSecure (either the newly created one or the pre-existing one looked up via existing\_client\_id). |
+| <a name="output_service_principal_client_id"></a> [service\_principal\_client\_id](#output\_service\_principal\_client\_id) | The object ID of the service principal used for Illumio CloudSecure (either a newly created one or a pre-existing one identified by service\_principal\_client\_id). |
 <!-- END_TF_DOCS -->

--- a/modules/azure_subscription/README.md
+++ b/modules/azure_subscription/README.md
@@ -34,8 +34,10 @@ No modules.
 | [azurerm_role_definition.illumio_fw_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [azurerm_role_definition.illumio_nsg_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 | [illumio-cloudsecure_azure_subscription.subscription](https://registry.terraform.io/providers/illumio/illumio-cloudsecure/latest/docs/resources/azure_subscription) | resource |
+| [terraform_data.validate_existing_credentials](https://developer.hashicorp.com/terraform/language/resources/terraform-data) | resource |
 | [time_rotating.secret_rotation](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating) | resource |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
+| [azuread_service_principal.existing](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
@@ -43,6 +45,8 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azure_secret_expiration_days"></a> [azure\_secret\_expiration\_days](#input\_azure\_secret\_expiration\_days) | The number of days the Azure service principal secret remains valid before requiring renewal. | `number` | `365` | no |
+| <a name="input_existing_client_id"></a> [existing\_client\_id](#input\_existing\_client\_id) | Optional. The client ID (application ID) of a pre-existing Azure AD application to use instead of creating a new one. When set, the module skips creating the azuread\_application, azuread\_service\_principal, and azuread\_application\_password resources and looks up the existing service principal by client\_id (which requires the executing identity to have directory read access). existing\_client\_secret must also be set. | `string` | `null` | no |
+| <a name="input_existing_client_secret"></a> [existing\_client\_secret](#input\_existing\_client\_secret) | Optional. The client secret for the pre-existing Azure AD application referenced by existing\_client\_id. Required when existing\_client\_id is set. Rotation of this secret is the caller's responsibility; azure\_secret\_expiration\_days is ignored in this mode. | `string` | `null` | no |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | The prefix given to all Azure resource names. | `string` | `"IllumioCloudIntegration"` | no |
 | <a name="input_mode"></a> [mode](#input\_mode) | The account's access mode, must be "ReadWrite" (default) or "Read". | `string` | `"ReadWrite"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of this subscription in CloudSecure. | `string` | n/a | yes |
@@ -55,5 +59,5 @@ No modules.
 | <a name="output_azure_secret_expiration_days"></a> [azure\_secret\_expiration\_days](#output\_azure\_secret\_expiration\_days) | The number of days the Azure service principal secret remains valid before requiring renewal. |
 | <a name="output_iam_name_prefix"></a> [iam\_name\_prefix](#output\_iam\_name\_prefix) | The prefix given to all Azure resource names. |
 | <a name="output_mode"></a> [mode](#output\_mode) | The account's access mode, must be "ReadWrite" (default) or "Read". |
-| <a name="output_service_principal_client_id"></a> [service\_principal\_client\_id](#output\_service\_principal\_client\_id) | The ID of the service principal created for Illumio CloudSecure. |
+| <a name="output_service_principal_client_id"></a> [service\_principal\_client\_id](#output\_service\_principal\_client\_id) | The object ID of the service principal used for Illumio CloudSecure (either the newly created one or the pre-existing one looked up via existing\_client\_id). |
 <!-- END_TF_DOCS -->

--- a/modules/azure_subscription/README.md
+++ b/modules/azure_subscription/README.md
@@ -3,6 +3,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >= 3.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 4.0 |
 | <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.2.0 |

--- a/modules/azure_subscription/main.tf
+++ b/modules/azure_subscription/main.tf
@@ -1,7 +1,36 @@
 data "azuread_client_config" "current" {}
 
+locals {
+  use_existing_app            = var.existing_client_id != null
+  client_id                   = local.use_existing_app ? var.existing_client_id : azuread_application.illumio_app[0].client_id
+  client_secret               = local.use_existing_app ? var.existing_client_secret : azuread_application_password.illumio_secret[0].value
+  service_principal_object_id = local.use_existing_app ? data.azuread_service_principal.existing[0].object_id : azuread_service_principal.illumio_sp[0].object_id
+}
+
+# Enforce both-or-neither for existing_client_id / existing_client_secret at plan time.
+resource "terraform_data" "validate_existing_credentials" {
+  input = {
+    id_set     = var.existing_client_id != null
+    secret_set = var.existing_client_secret != null
+  }
+
+  lifecycle {
+    precondition {
+      condition     = (var.existing_client_id == null) == (var.existing_client_secret == null)
+      error_message = "existing_client_id and existing_client_secret must both be set or both be null."
+    }
+  }
+}
+
+# Look up the pre-existing service principal when the caller supplies an app registration.
+data "azuread_service_principal" "existing" {
+  count     = local.use_existing_app ? 1 : 0
+  client_id = var.existing_client_id
+}
+
 # Azure AD Application
 resource "azuread_application" "illumio_app" {
+  count        = local.use_existing_app ? 0 : 1
   display_name = "${var.iam_name_prefix}App"
   description  = "Illumio CloudSecure Azure Subscription Integration"
   owners       = [data.azuread_client_config.current.object_id]
@@ -10,28 +39,31 @@ resource "azuread_application" "illumio_app" {
 
 # Service Principal for the Application
 resource "azuread_service_principal" "illumio_sp" {
-  client_id   = azuread_application.illumio_app.client_id
+  count       = local.use_existing_app ? 0 : 1
+  client_id   = azuread_application.illumio_app[0].client_id
   description = "Service Principal for Illumio CloudSecure Azure Subscription Integration"
   owners      = [data.azuread_client_config.current.object_id]
   tags        = var.tags
 }
 
 resource "time_rotating" "secret_rotation" {
+  count         = local.use_existing_app ? 0 : 1
   rotation_days = var.azure_secret_expiration_days
 }
 
 # Application Password
 resource "azuread_application_password" "illumio_secret" {
-  application_id = azuread_application.illumio_app.id
+  count          = local.use_existing_app ? 0 : 1
+  application_id = azuread_application.illumio_app[0].id
   display_name   = "${var.iam_name_prefix}Secret"
   rotate_when_changed = {
-    rotation = time_rotating.secret_rotation.id
+    rotation = time_rotating.secret_rotation[0].id
   }
 }
 
 # Assigning Reader Role for Subscription Scope
 resource "azurerm_role_assignment" "illumio_reader_role" {
-  principal_id         = azuread_service_principal.illumio_sp.object_id
+  principal_id         = local.service_principal_object_id
   description          = "Illumio Reader role assignment"
   role_definition_name = "Reader"
   scope                = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
@@ -86,7 +118,7 @@ resource "azurerm_role_definition" "illumio_fw_role" {
 # Assigning Role for Firewall
 resource "azurerm_role_assignment" "illumio_fw_assignment" {
   count              = var.mode == "ReadWrite" ? 1 : 0
-  principal_id       = azuread_service_principal.illumio_sp.object_id
+  principal_id       = local.service_principal_object_id
   description        = "Illumio Firewall role assignment"
   role_definition_id = azurerm_role_definition.illumio_fw_role[0].role_definition_resource_id
   scope              = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
@@ -121,7 +153,7 @@ resource "azurerm_role_definition" "illumio_nsg_role" {
 # Assigning Role for NSG
 resource "azurerm_role_assignment" "illumio_nsg_assignment" {
   count              = var.mode == "ReadWrite" ? 1 : 0
-  principal_id       = azuread_service_principal.illumio_sp.object_id
+  principal_id       = local.service_principal_object_id
   description        = "Illumio NSG role assignment"
   role_definition_id = azurerm_role_definition.illumio_nsg_role[0].role_definition_resource_id
   scope              = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
@@ -131,8 +163,8 @@ resource "azurerm_role_assignment" "illumio_nsg_assignment" {
 data "azurerm_subscription" "current" {}
 
 resource "illumio-cloudsecure_azure_subscription" "subscription" {
-  client_id       = azuread_application.illumio_app.client_id
-  client_secret   = base64encode(azuread_application_password.illumio_secret.value)
+  client_id       = local.client_id
+  client_secret   = base64encode(local.client_secret)
   name            = var.name
   subscription_id = data.azurerm_subscription.current.subscription_id
   tenant_id       = data.azurerm_subscription.current.tenant_id

--- a/modules/azure_subscription/main.tf
+++ b/modules/azure_subscription/main.tf
@@ -1,36 +1,21 @@
 data "azuread_client_config" "current" {}
 
 locals {
-  use_existing_app            = var.existing_client_id != null
-  client_id                   = local.use_existing_app ? var.existing_client_id : azuread_application.illumio_app[0].client_id
-  client_secret               = local.use_existing_app ? var.existing_client_secret : azuread_application_password.illumio_secret[0].value
-  service_principal_object_id = local.use_existing_app ? data.azuread_service_principal.existing[0].object_id : azuread_service_principal.illumio_sp[0].object_id
-}
-
-# Enforce both-or-neither for existing_client_id / existing_client_secret at plan time.
-resource "terraform_data" "validate_existing_credentials" {
-  input = {
-    id_set     = var.existing_client_id != null
-    secret_set = var.existing_client_secret != null
-  }
-
-  lifecycle {
-    precondition {
-      condition     = (var.existing_client_id == null) == (var.existing_client_secret == null)
-      error_message = "existing_client_id and existing_client_secret must both be set or both be null."
-    }
-  }
+  use_existing_service_principal = var.service_principal_client_id != null
+  client_id                      = local.use_existing_service_principal ? var.service_principal_client_id : azuread_application.illumio_app[0].client_id
+  client_secret                  = local.use_existing_service_principal ? var.service_principal_client_secret : azuread_application_password.illumio_secret[0].value
+  service_principal_object_id    = local.use_existing_service_principal ? data.azuread_service_principal.existing[0].object_id : azuread_service_principal.illumio_sp[0].object_id
 }
 
 # Look up the pre-existing service principal when the caller supplies an app registration.
 data "azuread_service_principal" "existing" {
-  count     = local.use_existing_app ? 1 : 0
-  client_id = var.existing_client_id
+  count     = local.use_existing_service_principal ? 1 : 0
+  client_id = var.service_principal_client_id
 }
 
 # Azure AD Application
 resource "azuread_application" "illumio_app" {
-  count        = local.use_existing_app ? 0 : 1
+  count        = local.use_existing_service_principal ? 0 : 1
   display_name = "${var.iam_name_prefix}App"
   description  = "Illumio CloudSecure Azure Subscription Integration"
   owners       = [data.azuread_client_config.current.object_id]
@@ -39,7 +24,7 @@ resource "azuread_application" "illumio_app" {
 
 # Service Principal for the Application
 resource "azuread_service_principal" "illumio_sp" {
-  count       = local.use_existing_app ? 0 : 1
+  count       = local.use_existing_service_principal ? 0 : 1
   client_id   = azuread_application.illumio_app[0].client_id
   description = "Service Principal for Illumio CloudSecure Azure Subscription Integration"
   owners      = [data.azuread_client_config.current.object_id]
@@ -47,13 +32,13 @@ resource "azuread_service_principal" "illumio_sp" {
 }
 
 resource "time_rotating" "secret_rotation" {
-  count         = local.use_existing_app ? 0 : 1
+  count         = local.use_existing_service_principal ? 0 : 1
   rotation_days = var.azure_secret_expiration_days
 }
 
 # Application Password
 resource "azuread_application_password" "illumio_secret" {
-  count          = local.use_existing_app ? 0 : 1
+  count          = local.use_existing_service_principal ? 0 : 1
   application_id = azuread_application.illumio_app[0].id
   display_name   = "${var.iam_name_prefix}Secret"
   rotate_when_changed = {

--- a/modules/azure_subscription/outputs.tf
+++ b/modules/azure_subscription/outputs.tf
@@ -1,6 +1,6 @@
 output "service_principal_client_id" {
   value       = local.service_principal_object_id
-  description = "The object ID of the service principal used for Illumio CloudSecure (either the newly created one or the pre-existing one looked up via existing_client_id)."
+  description = "The object ID of the service principal used for Illumio CloudSecure (either a newly created one or a pre-existing one identified by service_principal_client_id)."
 }
 
 output "iam_name_prefix" {

--- a/modules/azure_subscription/outputs.tf
+++ b/modules/azure_subscription/outputs.tf
@@ -1,6 +1,6 @@
 output "service_principal_client_id" {
-  value       = azuread_service_principal.illumio_sp.object_id
-  description = "The ID of the service principal created for Illumio CloudSecure."
+  value       = local.service_principal_object_id
+  description = "The object ID of the service principal used for Illumio CloudSecure (either the newly created one or the pre-existing one looked up via existing_client_id)."
 }
 
 output "iam_name_prefix" {

--- a/modules/azure_subscription/variables.tf
+++ b/modules/azure_subscription/variables.tf
@@ -42,3 +42,16 @@ variable "tags" {
   type        = set(string)
   default     = []
 }
+
+variable "existing_client_id" {
+  description = "Optional. The client ID (application ID) of a pre-existing Azure AD application to use instead of creating a new one. When set, the module skips creating the azuread_application, azuread_service_principal, and azuread_application_password resources and looks up the existing service principal by client_id (which requires the executing identity to have directory read access). existing_client_secret must also be set."
+  type        = string
+  default     = null
+}
+
+variable "existing_client_secret" {
+  description = "Optional. The client secret for the pre-existing Azure AD application referenced by existing_client_id. Required when existing_client_id is set. Rotation of this secret is the caller's responsibility; azure_secret_expiration_days is ignored in this mode."
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/modules/azure_subscription/variables.tf
+++ b/modules/azure_subscription/variables.tf
@@ -43,15 +43,25 @@ variable "tags" {
   default     = []
 }
 
-variable "existing_client_id" {
-  description = "Optional. The client ID (application ID) of a pre-existing Azure AD application to use instead of creating a new one. When set, the module skips creating the azuread_application, azuread_service_principal, and azuread_application_password resources and looks up the existing service principal by client_id (which requires the executing identity to have directory read access). existing_client_secret must also be set."
+variable "service_principal_client_id" {
+  description = "Optional. The client ID (application ID) of a pre-existing Azure AD application to use instead of creating a new one. When set, the module skips creating the azuread_application, azuread_service_principal, and azuread_application_password resources and looks up the existing service principal by client_id (which requires the executing identity to have directory read access). service_principal_client_secret must also be set."
   type        = string
+  nullable    = true
   default     = null
+  validation {
+    condition     = (var.service_principal_client_id == null) == (var.service_principal_client_secret == null)
+    error_message = "service_principal_client_id and service_principal_client_secret must both be set or both be null."
+  }
 }
 
-variable "existing_client_secret" {
-  description = "Optional. The client secret for the pre-existing Azure AD application referenced by existing_client_id. Required when existing_client_id is set. Rotation of this secret is the caller's responsibility; azure_secret_expiration_days is ignored in this mode."
+variable "service_principal_client_secret" {
+  description = "Optional. The client secret for the pre-existing Azure AD application identified by service_principal_client_id. Required when service_principal_client_id is set. Rotation of this secret is the caller's responsibility; azure_secret_expiration_days is ignored in this mode."
   type        = string
+  nullable    = true
   default     = null
   sensitive   = true
+  validation {
+    condition     = (var.service_principal_client_id == null) == (var.service_principal_client_secret == null)
+    error_message = "service_principal_client_id and service_principal_client_secret must both be set or both be null."
+  }
 }

--- a/modules/azure_subscription/versions.tf
+++ b/modules/azure_subscription/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.9"
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"


### PR DESCRIPTION
## Summary
- Add optional `service_principal_client_id` / `service_principal_client_secret` variables to the `azure_subscription` module so callers can reuse a pre-provisioned Azure AD application instead of having the module create one. Both variables may only be set together.
- When set, the module skips the `azuread_application`, `azuread_service_principal`, `azuread_application_password`, and `time_rotating.secret_rotation` resources and looks up the existing service principal via `data.azuread_service_principal` (by `client_id`) to obtain the `object_id` needed for role assignments.
- Role assignments and the `illumio-cloudsecure_azure_subscription` resource read the identity/secret from shared locals, so behavior is unchanged when the new variables are left at their `null` defaults.

## Notes
- When `service_principal_client_id` is provided, the identity running Terraform must have directory read access so the `azuread_service_principal` data source can resolve `object_id`. If that turns out to be a problem in practice, we can add a third variable to let callers pass the object ID directly.
- `azure_secret_expiration_days` has no effect in the existing-app mode — secret rotation is the caller's responsibility.

## Test plan
- [x] `terraform validate` on the module
- [ ] `terraform plan` with defaults (no existing app) — should show creation of the app/SP/password as before
- [ ] `terraform plan` with `existing_client_id` + `existing_client_secret` — should skip those resources and only create role definitions/assignments
- [ ] `terraform plan` with only one of the two variables set — should fail variable validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)