### PR TITLE
azure_subscription: Add create_azure_rbac_assignments, subscription_id, and tenant_id variables, and fix circular validation

### DIFF
--- a/examples/azure_subscription/README.md
+++ b/examples/azure_subscription/README.md
@@ -17,6 +17,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_azure_subscription_at_scale"></a> [azure\_subscription\_at\_scale](#module\_azure\_subscription\_at\_scale) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.6.8 |
 | <a name="module_azure_subscription_dev"></a> [azure\_subscription\_dev](#module\_azure\_subscription\_dev) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.6.8 |
 | <a name="module_azure_subscription_existing_sp"></a> [azure\_subscription\_existing\_sp](#module\_azure\_subscription\_existing\_sp) | illumio/cloudsecure/illumio//modules/azure_subscription | 1.6.8 |
 

--- a/examples/azure_subscription/main.tf
+++ b/examples/azure_subscription/main.tf
@@ -7,9 +7,9 @@ provider "azurerm" {
 }
 
 provider "azuread" {
-  client_id       = var.azure_client_id
-  client_secret   = var.azure_client_secret
-  tenant_id       = var.azure_tenant_id
+  client_id     = var.azure_client_id
+  client_secret = var.azure_client_secret
+  tenant_id     = var.azure_tenant_id
 }
 
 provider "illumio-cloudsecure" {
@@ -62,7 +62,7 @@ module "azure_subscription_at_scale" {
   service_principal_client_id     = var.illumio_service_principal_client_id
   service_principal_client_secret = var.illumio_service_principal_client_secret
 
-  skip_azure_rbac_assignments = true
-  subscription_id             = var.azure_subscription_id
-  tenant_id                   = var.azure_tenant_id
+  create_azure_rbac_assignments = false
+  subscription_id               = var.azure_subscription_id
+  tenant_id                     = var.azure_tenant_id
 }

--- a/examples/azure_subscription/main.tf
+++ b/examples/azure_subscription/main.tf
@@ -49,3 +49,20 @@ module "azure_subscription_existing_sp" {
     "Owner=John Doe"
   ]
 }
+
+# At-scale pattern: BYO service principal, RBAC managed at management group level,
+# and explicit subscription/tenant IDs to avoid one ARM data-source call per subscription.
+# This is the recommended pattern when onboarding hundreds of subscriptions via for_each.
+module "azure_subscription_at_scale" {
+  source  = "illumio/cloudsecure/illumio//modules/azure_subscription"
+  version = "1.6.8"
+  name    = "Test Azure Subscription (at-scale pattern)"
+  mode    = "Read"
+
+  service_principal_client_id     = var.illumio_service_principal_client_id
+  service_principal_client_secret = var.illumio_service_principal_client_secret
+
+  skip_azure_rbac_assignments = true
+  subscription_id             = var.azure_subscription_id
+  tenant_id                   = var.azure_tenant_id
+}

--- a/modules/azure_subscription/README.md
+++ b/modules/azure_subscription/README.md
@@ -45,12 +45,15 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_azure_secret_expiration_days"></a> [azure\_secret\_expiration\_days](#input\_azure\_secret\_expiration\_days) | The number of days the Azure service principal secret remains valid before requiring renewal. | `number` | `365` | no |
+| <a name="input_create_azure_rbac_assignments"></a> [create\_azure\_rbac\_assignments](#input\_create\_azure\_rbac\_assignments) | When true (default), create all Azure RBAC role definitions and assignments. Set this to false when RBAC is managed centrally at the management group level to avoid redundant subscription-scoped assignments. | `bool` | `true` | no |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | The prefix given to all Azure resource names. | `string` | `"IllumioCloudIntegration"` | no |
 | <a name="input_mode"></a> [mode](#input\_mode) | The account's access mode, must be "ReadWrite" (default) or "Read". | `string` | `"ReadWrite"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of this subscription in CloudSecure. | `string` | n/a | yes |
 | <a name="input_service_principal_client_id"></a> [service\_principal\_client\_id](#input\_service\_principal\_client\_id) | Optional. The client ID (application ID) of a pre-existing Azure AD application to use instead of creating a new one. When set, the module skips creating the azuread\_application, azuread\_service\_principal, and azuread\_application\_password resources and looks up the existing service principal by client\_id (which requires the executing identity to have directory read access). service\_principal\_client\_secret must also be set. | `string` | `null` | no |
 | <a name="input_service_principal_client_secret"></a> [service\_principal\_client\_secret](#input\_service\_principal\_client\_secret) | Optional. The client secret for the pre-existing Azure AD application identified by service\_principal\_client\_id. Required when service\_principal\_client\_id is set. Rotation of this secret is the caller's responsibility; azure\_secret\_expiration\_days is ignored in this mode. | `string` | `null` | no |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Optional. The Azure Subscription ID. When set together with tenant\_id, the module skips the azurerm\_subscription data source lookup, reducing ARM API calls per subscription. Recommended for at-scale for\_each patterns over many subscriptions. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The optional tags added to every configured Azure resource. | `set(string)` | `[]` | no |
+| <a name="input_tenant_id"></a> [tenant\_id](#input\_tenant\_id) | Optional. The Azure Tenant ID. When set together with subscription\_id, the module skips the azurerm\_subscription data source lookup. | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/azure_subscription/main.tf
+++ b/modules/azure_subscription/main.tf
@@ -5,6 +5,8 @@ locals {
   client_id                      = local.use_existing_service_principal ? var.service_principal_client_id : azuread_application.illumio_app[0].client_id
   client_secret                  = local.use_existing_service_principal ? var.service_principal_client_secret : azuread_application_password.illumio_secret[0].value
   service_principal_object_id    = local.use_existing_service_principal ? data.azuread_service_principal.existing[0].object_id : azuread_service_principal.illumio_sp[0].object_id
+  subscription_id                = var.subscription_id != null ? var.subscription_id : data.azurerm_subscription.current[0].subscription_id
+  tenant_id                      = var.tenant_id != null ? var.tenant_id : data.azurerm_subscription.current[0].tenant_id
 }
 
 # Look up the pre-existing service principal when the caller supplies an app registration.
@@ -48,15 +50,16 @@ resource "azuread_application_password" "illumio_secret" {
 
 # Assigning Reader Role for Subscription Scope
 resource "azurerm_role_assignment" "illumio_reader_role" {
+  count                = var.skip_azure_rbac_assignments ? 0 : 1
   principal_id         = local.service_principal_object_id
   description          = "Illumio Reader role assignment"
   role_definition_name = "Reader"
-  scope                = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
+  scope                = "/subscriptions/${local.subscription_id}"
 }
 
 # Role Definitions for Firewall
 resource "azurerm_role_definition" "illumio_fw_role" {
-  count       = var.mode == "ReadWrite" ? 1 : 0
+  count       = (!var.skip_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
   name        = "${var.iam_name_prefix}FirewallRole"
   description = "Illumio Firewall Administrator role"
 
@@ -96,22 +99,22 @@ resource "azurerm_role_definition" "illumio_fw_role" {
     ]
   }
 
-  assignable_scopes = ["/subscriptions/${data.azurerm_subscription.current.subscription_id}"]
-  scope             = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
+  assignable_scopes = ["/subscriptions/${local.subscription_id}"]
+  scope             = "/subscriptions/${local.subscription_id}"
 }
 
 # Assigning Role for Firewall
 resource "azurerm_role_assignment" "illumio_fw_assignment" {
-  count              = var.mode == "ReadWrite" ? 1 : 0
+  count              = (!var.skip_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
   principal_id       = local.service_principal_object_id
   description        = "Illumio Firewall role assignment"
   role_definition_id = azurerm_role_definition.illumio_fw_role[0].role_definition_resource_id
-  scope              = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
+  scope              = "/subscriptions/${local.subscription_id}"
 }
 
 # Role Definitions for NSG
 resource "azurerm_role_definition" "illumio_nsg_role" {
-  count       = var.mode == "ReadWrite" ? 1 : 0
+  count       = (!var.skip_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
   name        = "${var.iam_name_prefix}NSGRole"
   description = "Illumio Network Security Administrator role"
 
@@ -131,28 +134,30 @@ resource "azurerm_role_definition" "illumio_nsg_role" {
     ]
   }
 
-  assignable_scopes = ["/subscriptions/${data.azurerm_subscription.current.subscription_id}"]
-  scope             = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
+  assignable_scopes = ["/subscriptions/${local.subscription_id}"]
+  scope             = "/subscriptions/${local.subscription_id}"
 }
 
 # Assigning Role for NSG
 resource "azurerm_role_assignment" "illumio_nsg_assignment" {
-  count              = var.mode == "ReadWrite" ? 1 : 0
+  count              = (!var.skip_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
   principal_id       = local.service_principal_object_id
   description        = "Illumio NSG role assignment"
   role_definition_id = azurerm_role_definition.illumio_nsg_role[0].role_definition_resource_id
-  scope              = "/subscriptions/${data.azurerm_subscription.current.subscription_id}"
+  scope              = "/subscriptions/${local.subscription_id}"
 }
 
 
-data "azurerm_subscription" "current" {}
+data "azurerm_subscription" "current" {
+  count = var.subscription_id == null ? 1 : 0
+}
 
 resource "illumio-cloudsecure_azure_subscription" "subscription" {
   client_id       = local.client_id
   client_secret   = base64encode(local.client_secret)
   name            = var.name
-  subscription_id = data.azurerm_subscription.current.subscription_id
-  tenant_id       = data.azurerm_subscription.current.tenant_id
+  subscription_id = local.subscription_id
+  tenant_id       = local.tenant_id
   mode            = var.mode
 
   depends_on = [

--- a/modules/azure_subscription/main.tf
+++ b/modules/azure_subscription/main.tf
@@ -50,7 +50,7 @@ resource "azuread_application_password" "illumio_secret" {
 
 # Assigning Reader Role for Subscription Scope
 resource "azurerm_role_assignment" "illumio_reader_role" {
-  count                = var.skip_azure_rbac_assignments ? 0 : 1
+  count                = var.create_azure_rbac_assignments ? 1 : 0
   principal_id         = local.service_principal_object_id
   description          = "Illumio Reader role assignment"
   role_definition_name = "Reader"
@@ -59,7 +59,7 @@ resource "azurerm_role_assignment" "illumio_reader_role" {
 
 # Role Definitions for Firewall
 resource "azurerm_role_definition" "illumio_fw_role" {
-  count       = (!var.skip_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
+  count       = (var.create_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
   name        = "${var.iam_name_prefix}FirewallRole"
   description = "Illumio Firewall Administrator role"
 
@@ -105,7 +105,7 @@ resource "azurerm_role_definition" "illumio_fw_role" {
 
 # Assigning Role for Firewall
 resource "azurerm_role_assignment" "illumio_fw_assignment" {
-  count              = (!var.skip_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
+  count              = (var.create_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
   principal_id       = local.service_principal_object_id
   description        = "Illumio Firewall role assignment"
   role_definition_id = azurerm_role_definition.illumio_fw_role[0].role_definition_resource_id
@@ -114,7 +114,7 @@ resource "azurerm_role_assignment" "illumio_fw_assignment" {
 
 # Role Definitions for NSG
 resource "azurerm_role_definition" "illumio_nsg_role" {
-  count       = (!var.skip_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
+  count       = (var.create_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
   name        = "${var.iam_name_prefix}NSGRole"
   description = "Illumio Network Security Administrator role"
 
@@ -140,7 +140,7 @@ resource "azurerm_role_definition" "illumio_nsg_role" {
 
 # Assigning Role for NSG
 resource "azurerm_role_assignment" "illumio_nsg_assignment" {
-  count              = (!var.skip_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
+  count              = (var.create_azure_rbac_assignments && var.mode == "ReadWrite") ? 1 : 0
   principal_id       = local.service_principal_object_id
   description        = "Illumio NSG role assignment"
   role_definition_id = azurerm_role_definition.illumio_nsg_role[0].role_definition_resource_id

--- a/modules/azure_subscription/variables.tf
+++ b/modules/azure_subscription/variables.tf
@@ -62,10 +62,10 @@ variable "service_principal_client_secret" {
   }
 }
 
-variable "skip_azure_rbac_assignments" {
-  description = "When true, skip all Azure RBAC role definitions and assignments. Use this when RBAC is managed centrally at the management group level to avoid redundant subscription-scoped assignments."
+variable "create_azure_rbac_assignments" {
+  description = "When true (default), create all Azure RBAC role definitions and assignments. Set this to false when RBAC is managed centrally at the management group level to avoid redundant subscription-scoped assignments."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "subscription_id" {

--- a/modules/azure_subscription/variables.tf
+++ b/modules/azure_subscription/variables.tf
@@ -48,10 +48,6 @@ variable "service_principal_client_id" {
   type        = string
   nullable    = true
   default     = null
-  validation {
-    condition     = (var.service_principal_client_id == null) == (var.service_principal_client_secret == null)
-    error_message = "service_principal_client_id and service_principal_client_secret must both be set or both be null."
-  }
 }
 
 variable "service_principal_client_secret" {
@@ -64,4 +60,28 @@ variable "service_principal_client_secret" {
     condition     = (var.service_principal_client_id == null) == (var.service_principal_client_secret == null)
     error_message = "service_principal_client_id and service_principal_client_secret must both be set or both be null."
   }
+}
+
+variable "skip_azure_rbac_assignments" {
+  description = "When true, skip all Azure RBAC role definitions and assignments. Use this when RBAC is managed centrally at the management group level to avoid redundant subscription-scoped assignments."
+  type        = bool
+  default     = false
+}
+
+variable "subscription_id" {
+  description = "Optional. The Azure Subscription ID. When set together with tenant_id, the module skips the azurerm_subscription data source lookup, reducing ARM API calls per subscription. Recommended for at-scale for_each patterns over many subscriptions."
+  type        = string
+  nullable    = true
+  default     = null
+  validation {
+    condition     = (var.subscription_id == null) == (var.tenant_id == null)
+    error_message = "subscription_id and tenant_id must both be set or both be null."
+  }
+}
+
+variable "tenant_id" {
+  description = "Optional. The Azure Tenant ID. When set together with subscription_id, the module skips the azurerm_subscription data source lookup."
+  type        = string
+  nullable    = true
+  default     = null
 }


### PR DESCRIPTION
- Add `create_azure_rbac_assignments` (bool, default true): when set to false, skips the Reader role assignment and all ReadWrite-mode role definitions and assignments. Enables callers who manage RBAC at the management group level to avoid redundant subscription-scoped assignments.

- Add nullable `subscription_id` and `tenant_id` inputs (default null): when both are provided, the `azurerm_subscription` data source is skipped entirely, eliminating one ARM lookup per subscription. Together with `create_azure_rbac_assignments = false` and a BYO service principal this reduces Azure-side API calls to a single Illumio provider call per subscription — the recommended pattern for `for_each` over hundreds of subscriptions.

- Fix circular cross-variable validation (TF 1.9 cycle): remove the duplicate validation block from `service_principal_client_id`; the single validation on `service_principal_client_secret` is sufficient.

- Add third example module instance demonstrating the at-scale pattern: BYO SP + `create_azure_rbac_assignments = false` + explicit subscription/tenant IDs.