### PR TITLE
aws_account: Support BYO IAM role and explicit account/organization IDs

### DIFF
--- a/examples/aws_account/README.md
+++ b/examples/aws_account/README.md
@@ -14,7 +14,9 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_aws_account_at_scale"></a> [aws\_account\_at\_scale](#module\_aws\_account\_at\_scale) | illumio/cloudsecure/illumio//modules/aws_account | 1.6.8 |
 | <a name="module_aws_account_dev"></a> [aws\_account\_dev](#module\_aws\_account\_dev) | illumio/cloudsecure/illumio//modules/aws_account | 1.6.8 |
+| <a name="module_aws_account_existing_role"></a> [aws\_account\_existing\_role](#module\_aws\_account\_existing\_role) | illumio/cloudsecure/illumio//modules/aws_account | 1.6.8 |
 
 ## Resources
 
@@ -24,8 +26,12 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | The 12-digit AWS Account ID used by the at-scale example to skip the aws\_caller\_identity data source. | `string` | n/a | yes |
+| <a name="input_aws_organization_id"></a> [aws\_organization\_id](#input\_aws\_organization\_id) | The AWS Organizations organization ID (e.g., o-xxxxxxxxxx) used by the at-scale example to skip the aws\_organizations\_organization data source. | `string` | n/a | yes |
 | <a name="input_illumio_cloudsecure_client_id"></a> [illumio\_cloudsecure\_client\_id](#input\_illumio\_cloudsecure\_client\_id) | The OAuth 2 client identifier used to authenticate against the CloudSecure Config API. | `string` | n/a | yes |
 | <a name="input_illumio_cloudsecure_client_secret"></a> [illumio\_cloudsecure\_client\_secret](#input\_illumio\_cloudsecure\_client\_secret) | The OAuth 2 client secret used to authenticate against the CloudSecure Config API. | `string` | n/a | yes |
+| <a name="input_illumio_role_arn"></a> [illumio\_role\_arn](#input\_illumio\_role\_arn) | The ARN of a pre-existing IAM role to wire into the BYO-role example module instances. | `string` | n/a | yes |
+| <a name="input_illumio_role_external_id"></a> [illumio\_role\_external\_id](#input\_illumio\_role\_external\_id) | The sts:ExternalId expected by the pre-existing IAM role referenced by illumio\_role\_arn. | `string` | n/a | yes |
 
 ## Outputs
 

--- a/examples/aws_account/main.tf
+++ b/examples/aws_account/main.tf
@@ -16,8 +16,43 @@ module "aws_account_dev" {
   iam_name_prefix = "IllumioCloudIntegration"
   mode            = "ReadWrite"
 
-  tags    = {
+  tags = {
     Name  = "CloudSecure Account Policy"
     Owner = "Engineering"
   }
+}
+
+# Reuse a pre-existing IAM role (and its external ID) instead of letting the
+# module create the role, its inline policies, and the SecurityAudit attachment.
+# role_arn and role_external_id must both be set (or both null).
+module "aws_account_existing_role" {
+  source           = "illumio/cloudsecure/illumio//modules/aws_account"
+  version          = "1.6.8"
+  name             = "Test Account (existing role)"
+  mode             = "ReadWrite"
+  role_arn         = var.illumio_role_arn
+  role_external_id = var.illumio_role_external_id
+
+  tags = {
+    Name  = "CloudSecure Account Policy"
+    Owner = "Engineering"
+  }
+}
+
+# At-scale pattern: BYO IAM role plus explicit account_id and organization_id
+# to avoid the aws_caller_identity and aws_organizations_organization data
+# source calls per account. This is the recommended pattern when onboarding
+# many accounts via for_each, or when the calling identity lacks
+# organizations:DescribeOrganization.
+module "aws_account_at_scale" {
+  source  = "illumio/cloudsecure/illumio//modules/aws_account"
+  version = "1.6.8"
+  name    = "Test Account (at-scale pattern)"
+  mode    = "Read"
+
+  role_arn         = var.illumio_role_arn
+  role_external_id = var.illumio_role_external_id
+
+  account_id      = var.aws_account_id
+  organization_id = var.aws_organization_id
 }

--- a/examples/aws_account/variables.tf
+++ b/examples/aws_account/variables.tf
@@ -16,3 +16,40 @@ variable "illumio_cloudsecure_client_secret" {
     error_message = "The illumio_cloudsecure_client_secret value must not be empty."
   }
 }
+
+variable "illumio_role_arn" {
+  type        = string
+  description = "The ARN of a pre-existing IAM role to wire into the BYO-role example module instances."
+  validation {
+    condition     = length(var.illumio_role_arn) > 0
+    error_message = "The illumio_role_arn value must not be empty."
+  }
+}
+
+variable "illumio_role_external_id" {
+  type        = string
+  sensitive   = true
+  description = "The sts:ExternalId expected by the pre-existing IAM role referenced by illumio_role_arn."
+  validation {
+    condition     = length(var.illumio_role_external_id) > 0
+    error_message = "The illumio_role_external_id value must not be empty."
+  }
+}
+
+variable "aws_account_id" {
+  type        = string
+  description = "The 12-digit AWS Account ID used by the at-scale example to skip the aws_caller_identity data source."
+  validation {
+    condition     = length(var.aws_account_id) == 12
+    error_message = "The aws_account_id value must be a 12-digit number."
+  }
+}
+
+variable "aws_organization_id" {
+  type        = string
+  description = "The AWS Organizations organization ID (e.g., o-xxxxxxxxxx) used by the at-scale example to skip the aws_organizations_organization data source."
+  validation {
+    condition     = length(var.aws_organization_id) > 0
+    error_message = "The aws_organization_id value must not be empty."
+  }
+}

--- a/examples/aws_account/versions.tf
+++ b/examples/aws_account/versions.tf
@@ -5,7 +5,7 @@ terraform {
       version = ">= 1.0.11"
     }
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
       version = ">= 3.0"
     }
   }

--- a/modules/aws_account/README.md
+++ b/modules/aws_account/README.md
@@ -3,6 +3,7 @@
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.0 |
 | <a name="requirement_illumio-cloudsecure"></a> [illumio-cloudsecure](#requirement\_illumio-cloudsecure) | >= 1.0.11 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
@@ -37,15 +38,19 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_account_id"></a> [account\_id](#input\_account\_id) | Optional. The 12-digit AWS Account ID. When set, the module skips the aws\_caller\_identity data source lookup. Recommended for at-scale for\_each patterns over many accounts. | `string` | `null` | no |
 | <a name="input_iam_name_prefix"></a> [iam\_name\_prefix](#input\_iam\_name\_prefix) | The prefix given to all AWS IAM resource names. | `string` | `"IllumioCloudIntegration"` | no |
 | <a name="input_illumio_cloudsecure_account_id"></a> [illumio\_cloudsecure\_account\_id](#input\_illumio\_cloudsecure\_account\_id) | The CloudSecure AWS account ID that is given the IAM role. | `string` | `"712001342241"` | no |
 | <a name="input_mode"></a> [mode](#input\_mode) | The account's access mode, must be "ReadWrite" (default) or "Read". | `string` | `"ReadWrite"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of this account in CloudSecure. | `string` | n/a | yes |
+| <a name="input_organization_id"></a> [organization\_id](#input\_organization\_id) | Optional. The AWS Organizations organization ID (e.g., o-xxxxxxxxxx). When set, the module skips the aws\_organizations\_organization data source lookup, which is useful when the calling identity lacks organizations:DescribeOrganization or when running at scale. | `string` | `null` | no |
+| <a name="input_role_arn"></a> [role\_arn](#input\_role\_arn) | Optional. The ARN of a pre-existing IAM role to use instead of creating a new one. When set, the module skips creating the IAM role, its inline read/protection policies, the SecurityAudit attachment, and the random external ID. The supplied role must already trust the CloudSecure account via sts:AssumeRole with the supplied role\_external\_id and must carry the equivalent read (and, when mode = "ReadWrite", protection) permissions. role\_external\_id must also be set. | `string` | `null` | no |
+| <a name="input_role_external_id"></a> [role\_external\_id](#input\_role\_external\_id) | Optional. The sts:ExternalId expected by the pre-existing IAM role identified by role\_arn. Required when role\_arn is set. Rotation of this value is the caller's responsibility. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The optional tags added to every configured AWS resource. | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_role_id"></a> [role\_id](#output\_role\_id) | The ID of the IAM role granted to the CloudSecure account. |
+| <a name="output_role_id"></a> [role\_id](#output\_role\_id) | The ID (or ARN, when role\_arn is supplied) of the IAM role granted to the CloudSecure account. |
 <!-- END_TF_DOCS -->

--- a/modules/aws_account/main.tf
+++ b/modules/aws_account/main.tf
@@ -1,6 +1,17 @@
-data "aws_partition" "current" {}
+locals {
+  use_existing_role = var.role_arn != null
+  role_arn          = local.use_existing_role ? var.role_arn : aws_iam_role.role[0].arn
+  role_external_id  = local.use_existing_role ? var.role_external_id : random_password.role_secret[0].result
+  account_id        = var.account_id != null ? var.account_id : data.aws_caller_identity.current[0].account_id
+  organization_id   = var.organization_id != null ? var.organization_id : data.aws_organizations_organization.current[0].id
+}
+
+data "aws_partition" "current" {
+  count = local.use_existing_role ? 0 : 1
+}
 
 resource "random_password" "role_secret" {
+  count       = local.use_existing_role ? 0 : 1
   length      = 36
   special     = false
   upper       = false
@@ -8,14 +19,15 @@ resource "random_password" "role_secret" {
 }
 
 resource "aws_iam_role_policy" "read" {
-  name = "${var.iam_name_prefix}Policy"
-  role = aws_iam_role.role.id
+  count = local.use_existing_role ? 0 : 1
+  name  = "${var.iam_name_prefix}Policy"
+  role  = aws_iam_role.role[0].id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = [
+        Effect = "Allow"
+        Action = [
           "apigateway:GET",
           "autoscaling:Describe*",
           "cloudtrail:DescribeTrails",
@@ -100,15 +112,15 @@ resource "aws_iam_role_policy" "read" {
 }
 
 resource "aws_iam_role_policy" "protection" {
-  count = var.mode == "ReadWrite" ? 1 : 0
-  name = "${var.iam_name_prefix}ProtectionPolicy"
-  role = aws_iam_role.role.id
+  count = (!local.use_existing_role && var.mode == "ReadWrite") ? 1 : 0
+  name  = "${var.iam_name_prefix}ProtectionPolicy"
+  role  = aws_iam_role.role[0].id
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Effect   = "Allow"
-        Action   = [
+        Effect = "Allow"
+        Action = [
           "ec2:AuthorizeSecurityGroupIngress",
           "ec2:RevokeSecurityGroupIngress",
           "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
@@ -138,20 +150,21 @@ resource "aws_iam_role_policy" "protection" {
 }
 
 resource "aws_iam_role" "role" {
-  name = "${var.iam_name_prefix}Role"
-  tags = var.tags
+  count = local.use_existing_role ? 0 : 1
+  name  = "${var.iam_name_prefix}Role"
+  tags  = var.tags
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
     Statement = [
       {
-        Effect    = "Allow"
+        Effect = "Allow"
         Principal = {
-          AWS = "arn:${data.aws_partition.current.partition}:iam::${var.illumio_cloudsecure_account_id}:root"
+          AWS = "arn:${data.aws_partition.current[0].partition}:iam::${var.illumio_cloudsecure_account_id}:root"
         }
-        Action    = "sts:AssumeRole"
+        Action = "sts:AssumeRole"
         Condition = {
           StringEquals = {
-            "sts:ExternalId" = random_password.role_secret.result
+            "sts:ExternalId" = random_password.role_secret[0].result
           }
         }
       }
@@ -160,22 +173,27 @@ resource "aws_iam_role" "role" {
 }
 
 resource "aws_iam_role_policy_attachment" "attachment" {
-  role       = aws_iam_role.role.name
+  count      = local.use_existing_role ? 0 : 1
+  role       = aws_iam_role.role[0].name
   policy_arn = "arn:aws:iam::aws:policy/SecurityAudit"
 }
 
 # Data source to get the AWS account ID.
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+  count = var.account_id == null ? 1 : 0
+}
 
 # Data source to get the AWS org.
-data "aws_organizations_organization" "current" {}
+data "aws_organizations_organization" "current" {
+  count = var.organization_id == null ? 1 : 0
+}
 
 // Onboards this AWS account with CloudSecure.
 resource "illumio-cloudsecure_aws_account" "account" {
-  account_id       = data.aws_caller_identity.current.account_id
+  account_id       = local.account_id
   mode             = var.mode
   name             = var.name
-  organization_id  = data.aws_organizations_organization.current.id
-  role_arn         = aws_iam_role.role.arn
-  role_external_id = random_password.role_secret.result
+  organization_id  = local.organization_id
+  role_arn         = local.role_arn
+  role_external_id = local.role_external_id
 }

--- a/modules/aws_account/outputs.tf
+++ b/modules/aws_account/outputs.tf
@@ -1,4 +1,4 @@
 output "role_id" {
-  value       = aws_iam_role.role.id
-  description = "The ID of the IAM role granted to the CloudSecure account."
+  value       = local.use_existing_role ? var.role_arn : aws_iam_role.role[0].id
+  description = "The ID (or ARN, when role_arn is supplied) of the IAM role granted to the CloudSecure account."
 }

--- a/modules/aws_account/variables.tf
+++ b/modules/aws_account/variables.tf
@@ -42,3 +42,40 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "role_arn" {
+  description = "Optional. The ARN of a pre-existing IAM role to use instead of creating a new one. When set, the module skips creating the IAM role, its inline read/protection policies, the SecurityAudit attachment, and the random external ID. The supplied role must already trust the CloudSecure account via sts:AssumeRole with the supplied role_external_id and must carry the equivalent read (and, when mode = \"ReadWrite\", protection) permissions. role_external_id must also be set."
+  type        = string
+  nullable    = true
+  default     = null
+}
+
+variable "role_external_id" {
+  description = "Optional. The sts:ExternalId expected by the pre-existing IAM role identified by role_arn. Required when role_arn is set. Rotation of this value is the caller's responsibility."
+  type        = string
+  nullable    = true
+  default     = null
+  sensitive   = true
+  validation {
+    condition     = (var.role_arn == null) == (var.role_external_id == null)
+    error_message = "role_arn and role_external_id must both be set or both be null."
+  }
+}
+
+variable "account_id" {
+  description = "Optional. The 12-digit AWS Account ID. When set, the module skips the aws_caller_identity data source lookup. Recommended for at-scale for_each patterns over many accounts."
+  type        = string
+  nullable    = true
+  default     = null
+  validation {
+    condition     = var.account_id == null || length(var.account_id) == 12
+    error_message = "The account_id value must be a 12-digit number."
+  }
+}
+
+variable "organization_id" {
+  description = "Optional. The AWS Organizations organization ID (e.g., o-xxxxxxxxxx). When set, the module skips the aws_organizations_organization data source lookup, which is useful when the calling identity lacks organizations:DescribeOrganization or when running at scale."
+  type        = string
+  nullable    = true
+  default     = null
+}

--- a/modules/aws_account/versions.tf
+++ b/modules/aws_account/versions.tf
@@ -1,4 +1,5 @@
 terraform {
+  required_version = ">= 1.9"
   required_providers {
     illumio-cloudsecure = {
       source  = "illumio/illumio-cloudsecure"


### PR DESCRIPTION
## Summary

Brings the at-scale onboarding pattern shipped for `azure_subscription` in PR #60 (existing service principal) and the follow-up `skip_azure_rbac_assignments` / explicit `subscription_id` work over to `aws_account`:

- **BYO IAM role**: new optional `role_arn` + `role_external_id` (paired cross-variable validation). When set, the module skips `aws_iam_role.role`, the inline read/protection policies, the `SecurityAudit` attachment, the `random_password.role_secret`, and the `aws_partition` data source.
- **Explicit `account_id` / `organization_id`**: new optional vars that, when set, gate off the `aws_caller_identity` and `aws_organizations_organization` data sources. Useful for identities that lack `organizations:DescribeOrganization` (common in restricted member accounts) and for `for_each` over many accounts where the per-account API call cost adds up.
- **Locals** select between explicit var and data-source / generated value; `illumio-cloudsecure_aws_account` consumes the locals.
- **`versions.tf`**: bumped to `terraform >= 1.9` (cross-variable validation, matching `azure_subscription`).
- **Example**: adds two new module instances (`aws_account_existing_role`, `aws_account_at_scale`) mirroring the `azure_subscription` example layout.
- **READMEs**: regenerated with `terraform-docs:0.20.0`.

### Backwards compatibility

All new variables default to `null`. With no caller changes, the module behaves exactly as before. No state migration required.

### At-scale AWS API call savings per onboarded account

| Mode | AWS calls today | AWS calls after |
|---|---|---|
| Default (module-managed role) | 3 data-source reads + 4 IAM writes + 1 Illumio | unchanged |
| BYO role + explicit IDs | n/a | 1 Illumio call |

This is the same shape of reduction targeted by the `azure_subscription` scale follow-up, and is the practical fix for callers running the module via `for_each` over many AWS accounts.

## Test plan

- [ ] `terraform validate` passes on TF 1.9+ for `modules/aws_account` (verified locally with 1.9.8).
- [ ] `terraform fmt -check -recursive modules/aws_account examples/aws_account` clean.
- [ ] `terraform plan` for the default `aws_account_dev` instance shows no resource diff against a pre-change state (backward compatible).
- [ ] `terraform plan` for `aws_account_existing_role` creates only the `illumio-cloudsecure_aws_account` resource; no IAM or `random_password` resources.
- [ ] `terraform plan` for `aws_account_at_scale` additionally shows zero `aws_caller_identity` / `aws_organizations_organization` data reads in the graph.
- [ ] Apply each variant against a real AWS account / Illumio CloudSecure tenant and confirm the onboarded account appears in CloudSecure with the expected mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)